### PR TITLE
Replace exists() with existsSync() for consistency with pathwatcher.

### DIFF
--- a/node_modules/pathwatcher/lib/file.js
+++ b/node_modules/pathwatcher/lib/file.js
@@ -97,7 +97,7 @@
     };
 
     File.prototype.willAddSubscription = function() {
-      if (this.exists() && this.subscriptionCount === 0) {
+      if (this.existsSync() && this.subscriptionCount === 0) {
         this.subscribeToNativeChangeEvents();
       }
       return this.subscriptionCount++;
@@ -132,7 +132,7 @@
       return false;
     };
 
-    File.prototype.exists = function() {
+    File.prototype.existsSync = function() {
       return fs.existsSync(this.getPath());
     };
 
@@ -203,7 +203,7 @@
 
     File.prototype.readSync = function(flushCache) {
       var encoding;
-      if (!this.exists()) {
+      if (!this.existsSync()) {
         this.cachedContents = null;
       } else if ((this.cachedContents == null) || flushCache) {
         encoding = this.getEncoding();
@@ -240,7 +240,7 @@
       if (Q == null) {
         Q = require('q');
       }
-      if (!this.exists()) {
+      if (!this.existsSync()) {
         promise = Q(null);
       } else if ((this.cachedContents == null) || flushCache) {
         deferred = Q.defer();
@@ -282,7 +282,7 @@
 
     File.prototype.write = function(text) {
       var previouslyExisted;
-      previouslyExisted = this.exists();
+      previouslyExisted = this.existsSync();
       this.writeFileWithPrivilegeEscalationSync(this.getPath(), text);
       this.cachedContents = text;
       if (!previouslyExisted && this.hasSubscriptions()) {
@@ -350,7 +350,7 @@
     };
 
     File.prototype.detectResurrection = function() {
-      if (this.exists()) {
+      if (this.existsSync()) {
         this.subscribeToNativeChangeEvents();
         return this.handleNativeChangeEvent('change', this.getPath());
       } else {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "ti-create:project"
   ],
   "engines": {
-    "atom": "*"
+    "atom": ">=0.180.0"
   },
   "dependencies": {
-    "pathwatcher": "^2"
+    "pathwatcher": "^4"
   },
   "readme": "# ti-create - Appcelerator Alloy Create package\n\nCreates a controller (including view and style) and widgets for an Titanium Alloy project.\nXML file will have a basic window layout.\n\nworks inside Alloy projects (open folder - project folder)\n",
   "readmeFilename": "README.md",


### PR DESCRIPTION
`File::exists()` is deprecated in pathwatcher 3.3.0:
https://github.com/atom/node-pathwatcher/commit/6d6f2666dabe581111808a8cbe856d8429f0f21b

Atom started pulling in pathwatcher 3.3.1 in version 0.180.0:
https://github.com/atom/atom/commit/c260a29434547493d5f22508e2afd2da96f13f40