### PR TITLE
fix bug : create model

### DIFF
--- a/lib/ti-create.js
+++ b/lib/ti-create.js
@@ -12,7 +12,7 @@ module.exports = {
         atom.commands.add('atom-workspace', 'ti-create:controller', this.createController);
         atom.commands.add('atom-workspace', 'ti-create:widget', this.createWidget);
         atom.commands.add('atom-workspace', 'ti-create:project', this.createProject);
-        atom.commands.add('atom-workspace', 'ti-create:model', this.createProject);
+        atom.commands.add('atom-workspace', 'ti-create:model', this.createModel);
     },
 
     createController: function() {
@@ -49,7 +49,7 @@ function runProcess(options, args, what, filename) {
         } else if (what == "widget") {
             targetPath = path.join(atom.project.getPaths()[0], 'app', 'widgets', filename, 'controllers', 'widget.js');
         } else if (what == "model") {
-            targetPath = path.join(atom.project.getPaths()[0], 'app', 'model', filename + '.js');
+            targetPath = path.join(atom.project.getPaths()[0], 'app', 'models', filename + '.js');
         }
         if (targetPath && fs.statSync(targetPath).isFile()) {
             atom.workspace.open(targetPath);


### PR DESCRIPTION
Thanks for adding creating model feature.
I found a bug of that and fix it.

----

Additionally, I have a one more suggestion.
How about setting the adapter to 'properties' as default adapter when ti-create models?
Because Changing adapter type and model specification on Atom editor is easier than on "Model panel".
If you agree, I will make a another pull request. :smile: 

Thanks.